### PR TITLE
[SVR-138] [전투 씬] 배치 화면 전환

### DIFF
--- a/MockBattle/scenes/battle.gd
+++ b/MockBattle/scenes/battle.gd
@@ -1,0 +1,6 @@
+extends Node2D
+
+
+
+func _on_change_scene_pressed():
+	 get_tree().change_scene("res://scenes/settings.tscn")

--- a/MockBattle/scenes/battle.tscn
+++ b/MockBattle/scenes/battle.tscn
@@ -1,17 +1,19 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://sub_title.tres" type="DynamicFont" id=1]
+[ext_resource path="res://scenes/battle.gd" type="Script" id=2]
 
 [sub_resource type="StyleBoxFlat" id=1]
 bg_color = Color( 0.92549, 0.305882, 0.305882, 1 )
 
 [node name="Battle" type="Node2D"]
+script = ExtResource( 2 )
 
 [node name="temp_bg" type="ColorRect" parent="."]
 margin_right = 1024.0
 margin_bottom = 600.0
 
-[node name="Button" type="Button" parent="."]
+[node name="change_scene" type="Button" parent="."]
 margin_left = 30.0
 margin_top = 16.0
 margin_right = 252.0
@@ -19,3 +21,5 @@ margin_bottom = 87.0
 custom_fonts/font = ExtResource( 1 )
 custom_styles/normal = SubResource( 1 )
 text = "세팅하기"
+
+[connection signal="pressed" from="change_scene" to="." method="_on_change_scene_pressed"]

--- a/MockBattle/scenes/settings.gd
+++ b/MockBattle/scenes/settings.gd
@@ -2,3 +2,13 @@ extends Control
 
 func _on_game_start_pressed():
 	 get_tree().change_scene("res://scenes/battle.tscn")
+
+func _ready():
+	var batch_settings = Settings.get_batch_setting()
+	var command_settings = Settings.get_command_settings()
+	
+	$defensive_character/edit.text = batch_settings.get("defense", "")
+	$attack_character/edit.text = batch_settings.get("attack", "")
+	
+	$defensive_command/edit.text = command_settings.get("defense", "")
+	$attack_command/edit.text = command_settings.get("attack", "")

--- a/MockBattle/singletons/settings.gd
+++ b/MockBattle/singletons/settings.gd
@@ -20,12 +20,11 @@ func get_command_settings() -> Dictionary:
 func update_defense_batch_settings(setting: String):
 	batch_settings.defense = setting
 	
-
 func update_attack_batch_settings(setting: String):
 	batch_settings.attack = setting
 
 func update_defense_command_settings(setting: String):
-	batch_settings.defense = setting
+	command_settings.defense = setting
 
 func update_attack_command_settings(setting: String):
-	batch_settings.attack = setting
+	command_settings.attack = setting


### PR DESCRIPTION
- 전투 씬에서 배치 화면 전환 버튼을 누르면 배치 화면으로 돌아갑니다.
- 그리고 배치 화면으로 다시 돌아갔을때, 이미 설정해두었던 세팅 값이 있다면 복원시키는 기능을 추가했습니다.
- 그리고 세팅 씬의 업데이트 코드를 잘못 짜뒀길래 수정했어요