### PR TITLE
[SVR-188] & [SVR-194] [전투 씬] 목업 캐릭터 전체 생성 & 목업 캐릭터의 데이터 주입 

### DIFF
--- a/MockBattle/scenes/characters/cake.tscn
+++ b/MockBattle/scenes/characters/cake.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://scenes/characters/cake.gd" id="2"]
 [ext_resource type="PackedScene" uid="uid://b3qxr885pjvvh" path="res://scenes/props/health_bar.tscn" id="3"]
-[ext_resource type="SpriteFrames" uid="uid://cslym11udvobd" path="res://addons/duelyst_animated_sprites/assets/spriteframes/units/boss_grym.tres" id="3_u4cci"]
+[ext_resource type="SpriteFrames" uid="uid://d4cx26703ou5w" path="res://addons/duelyst_animated_sprites/assets/spriteframes/units/boss_grym.tres" id="3_u4cci"]
 
 [node name="food" type="Area2D"]
 script = ExtResource("2")
@@ -17,7 +17,5 @@ offset_bottom = -8.0
 position = Vector2(14, 23)
 scale = Vector2(1.4, 1.4)
 sprite_frames = ExtResource("3_u4cci")
-animation = &"attack"
+animation = &"run"
 offset = Vector2(47.6667, 27.5)
-
-[node name="AnimationPlayer" type="AnimationPlayer" parent="."]

--- a/MockBattle/scenes/characters/jjajang.tscn
+++ b/MockBattle/scenes/characters/jjajang.tscn
@@ -17,5 +17,5 @@ offset_bottom = -10.0
 position = Vector2(9.53674e-07, 0)
 scale = Vector2(1.8, 1.8)
 sprite_frames = ExtResource("3_t6myi")
-animation = &"breathing"
+animation = &"idle"
 offset = Vector2(40.7143, 40)

--- a/MockBattle/scenes/characters/jjambbong.tscn
+++ b/MockBattle/scenes/characters/jjambbong.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://scenes/characters/jjambbong.gd" id="2"]
 [ext_resource type="PackedScene" uid="uid://b3qxr885pjvvh" path="res://scenes/props/health_bar.tscn" id="3"]
-[ext_resource type="SpriteFrames" uid="uid://crblbpanulhwa" path="res://addons/duelyst_animated_sprites/assets/spriteframes/units/boss_umbra.tres" id="3_xd12i"]
+[ext_resource type="SpriteFrames" uid="uid://c7kwrxn1ii4u8" path="res://addons/duelyst_animated_sprites/assets/spriteframes/units/boss_umbra.tres" id="3_xd12i"]
 
 [node name="food" type="Area2D"]
 script = ExtResource("2")
@@ -17,5 +17,5 @@ offset_bottom = -6.0
 position = Vector2(15, -13)
 scale = Vector2(1.6, 1.6)
 sprite_frames = ExtResource("3_xd12i")
-animation = &"idle"
+animation = &"run"
 offset = Vector2(39.2857, 39.2857)

--- a/MockBattle/scenes/characters/kung_pao_chicken.gd
+++ b/MockBattle/scenes/characters/kung_pao_chicken.gd
@@ -1,0 +1,35 @@
+extends "res://scenes/characters/player.gd"
+
+func _ready():
+	set_health(80)
+	
+	food_name = "꿔바로우"
+	
+	defense = 30
+	resistance = 20
+	evasion = 0
+	critical_chance = 20
+	
+	skill_1_settings = SkillSettings.new(15, -1)
+	skill_2_settings = SkillSettings.new(15, -1, 1)
+
+func skill_1(team, enemies, turn, meta):
+	# 스킬 1 (발동 15)
+	# 모든 상대에게 데미지 20을 줍니다.
+	super(team, enemies, turn, meta)
+
+	for key in enemies:
+		var enemy: InstanceMap = enemies[key]
+		
+		enemy.instance_node.take_damage(20, skill_1_settings.target_direction)
+
+func skill_2(team, enemies, turn, meta):
+	# 스킬 2 (발동 15, 중단)
+	# 모든 상대에게 데미지 10을 줍니다.
+
+	super(team, enemies, turn, meta)
+	
+	for key in enemies:
+		var enemy: InstanceMap = enemies[key]
+		
+		enemy.instance_node.take_damage(10, skill_2_settings.target_direction)

--- a/MockBattle/scenes/characters/kung_pao_chicken.tscn
+++ b/MockBattle/scenes/characters/kung_pao_chicken.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=4 format=3 uid="uid://bhvdil3cwn2q2"]
+
+[ext_resource type="Script" path="res://scenes/characters/kung_pao_chicken.gd" id="1_dwtwb"]
+[ext_resource type="SpriteFrames" uid="uid://den5ja0mr2fev" path="res://addons/duelyst_animated_sprites/assets/spriteframes/units/boss_skurge.tres" id="2_11sjg"]
+[ext_resource type="PackedScene" uid="uid://b3qxr885pjvvh" path="res://scenes/props/health_bar.tscn" id="2_76hns"]
+
+[node name="food" type="Area2D"]
+script = ExtResource("1_dwtwb")
+
+[node name="health_bar" parent="." instance=ExtResource("2_76hns")]
+offset_left = 9.0
+offset_top = 0.0
+offset_right = 9.0
+offset_bottom = 0.0
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+position = Vector2(9.53674e-07, 0)
+scale = Vector2(1.8, 1.8)
+sprite_frames = ExtResource("2_11sjg")
+animation = &"run"
+offset = Vector2(40.7143, 40)

--- a/MockBattle/scenes/characters/mala_tang.gd
+++ b/MockBattle/scenes/characters/mala_tang.gd
@@ -1,0 +1,36 @@
+extends "res://scenes/characters/player.gd"
+
+func _ready():
+	set_health(130)
+	
+	food_name = "마라탕"
+	
+	defense = 20
+	resistance = 0
+	evasion = 0
+	critical_chance = 0
+	
+	skill_1_settings = SkillSettings.new(14, 2)
+	skill_2_settings = SkillSettings.new(20, -1, 1)
+
+func skill_1(team, enemies, turn, meta):
+	# 스킬 1 (발동 14, 2턴 지속)
+	# 1열에 있는 음식들에게 데미지 5와 기절 상태이상을 부여합니다.
+	super(team, enemies, turn, meta)
+
+	var targets = get_foods_at_selected_area(0, enemies)
+	
+	for enemy in targets:
+		enemy.take_damage(calculate_inflicted_damage(5), skill_1_settings.target_direction)
+		enemy.toggle_stun(true)
+
+func skill_2(team, enemies, turn, meta):
+	# 스킬 2 (발동 20, 중단)
+	# 1열에 있는 음식들에게 데미지 60을 줍니다.
+
+	super(team, enemies, turn, meta)
+
+	var targets = get_foods_at_selected_area(0, enemies)
+
+	for enemy in targets:
+		enemy.take_damage(calculate_inflicted_damage(60), skill_2_settings.target_direction)

--- a/MockBattle/scenes/characters/mala_tang.tscn
+++ b/MockBattle/scenes/characters/mala_tang.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=4 format=3 uid="uid://b5flerjh8n7em"]
+
+[ext_resource type="Script" path="res://scenes/characters/mala_tang.gd" id="1_xstbk"]
+[ext_resource type="PackedScene" uid="uid://b3qxr885pjvvh" path="res://scenes/props/health_bar.tscn" id="2_201u5"]
+[ext_resource type="SpriteFrames" uid="uid://d0lsy4mvml3fs" path="res://addons/duelyst_animated_sprites/assets/spriteframes/units/boss_legion.tres" id="3_p2dg5"]
+
+[node name="food" type="Area2D"]
+script = ExtResource("1_xstbk")
+
+[node name="health_bar" parent="." instance=ExtResource("2_201u5")]
+offset_left = 9.0
+offset_top = 0.0
+offset_right = 9.0
+offset_bottom = 0.0
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+position = Vector2(9.53674e-07, 0)
+scale = Vector2(1.8, 1.8)
+sprite_frames = ExtResource("3_p2dg5")
+animation = &"run"
+frame_progress = 0.613944
+offset = Vector2(40.7143, 40)

--- a/MockBattle/scenes/characters/mala_xiang_guo.gd
+++ b/MockBattle/scenes/characters/mala_xiang_guo.gd
@@ -1,0 +1,49 @@
+extends "res://scenes/characters/player.gd"
+
+func _ready():
+	set_health(80)
+	
+	food_name = "마라샹궈"
+	
+	defense = 10
+	resistance = 40
+	evasion = 30
+	critical_chance = 40
+	
+	skill_1_settings = SkillSettings.new(10, 3)
+	skill_2_settings = SkillSettings.new(18, -1, 1)
+	
+
+func skill_1(team, enemies, turn, meta):
+	# 스킬 1 (발동 10, 3턴 지속)
+	# 체력이 가장 낮은 음식 하나에게 데미지 10과 방어력 감소 10을 부여합니다.
+	
+	super(team, enemies, turn, meta)
+	
+	var effect = SkillEffect.new(
+		self.get_id(),
+		turn,
+		skill_1_settings.persistent_turn,
+		Settings.SkillEffectType.CHANGED_PLAYER_STATUS,
+		-10,
+		"defense"
+	)
+	
+	var target = get_most_unheath_food(enemies)
+	var result_target: Player = target.get_matching_character_to_tanking(enemies)
+	
+	if result_target:
+		result_target.take_damage(calculate_inflicted_damage(35), skill_1_settings.target_direction)
+		result_target.defense += -10
+		result_target.add_skill_effect(effect)
+		
+func skill_2(team, enemies, turn, meta):
+	# 스킬 2 (발동 18, 중단)
+	# 체력이 가장 낮은 음식 하나에게 데미지 50 줍니다.
+	super(team, enemies, turn, meta)
+	
+	var target = get_most_unheath_food(enemies)
+	var result_target: Player = target.get_matching_character_to_tanking(enemies)
+	
+	if result_target:
+		result_target.take_damage(calculate_inflicted_damage(50), skill_2_settings.target_direction)

--- a/MockBattle/scenes/characters/mala_xiang_guo.tscn
+++ b/MockBattle/scenes/characters/mala_xiang_guo.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=4 format=3 uid="uid://emnwpramckv5"]
+
+[ext_resource type="Script" path="res://scenes/characters/seasoned_bellflower_root.gd" id="1_mvpoa"]
+[ext_resource type="PackedScene" uid="uid://b3qxr885pjvvh" path="res://scenes/props/health_bar.tscn" id="2_5p47q"]
+[ext_resource type="SpriteFrames" uid="uid://didukbtoid7fp" path="res://addons/duelyst_animated_sprites/assets/spriteframes/units/boss_kane.tres" id="3_x1nvr"]
+
+[node name="food" type="Area2D"]
+script = ExtResource("1_mvpoa")
+
+[node name="health_bar" parent="." instance=ExtResource("2_5p47q")]
+offset_left = 9.0
+offset_top = 0.0
+offset_right = 9.0
+offset_bottom = 0.0
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+position = Vector2(9.53674e-07, 0)
+scale = Vector2(1.8, 1.8)
+sprite_frames = ExtResource("3_x1nvr")
+animation = &"hit"
+offset = Vector2(40.7143, 40)

--- a/MockBattle/scenes/characters/milk_shake.gd
+++ b/MockBattle/scenes/characters/milk_shake.gd
@@ -1,0 +1,45 @@
+extends "res://scenes/characters/player.gd"
+
+var is_skill_effect_enable: bool
+
+func _ready():
+	set_health(100)
+	
+	food_name = "밀크쉐이크"
+	
+	defense = 10
+	resistance = 0
+	evasion = 0
+	critical_chance = 0
+	
+	skill_1_settings = SkillSettings.new(5, -1)
+	skill_2_settings = SkillSettings.new(25, -1, 1)
+	
+	is_skill_effect_enable = false
+
+func skill_1(team, enemies, turn, meta):
+	# 스킬 1 (발동 5)
+	# 다음 시전되는 스킬 2의 공격력을 10 증가시킵니다.
+	
+	super(team, enemies, turn, meta)
+	
+	is_skill_effect_enable = true
+	
+		
+func skill_2(team, enemies, turn, meta):
+	# 스킬 2 (발동 25, 중단)
+	# 모든 상대에게 데미지 30을 줍니다.
+
+	super(team, enemies, turn, meta)
+	
+	var damage: int = 30
+	
+	if is_skill_effect_enable:
+		damage += 10
+		is_skill_effect_enable = false
+	
+	for key in enemies:
+		var enemy: InstanceMap = enemies[key]
+		
+		enemy.instance_node.take_damage(damage, skill_2_settings.target_direction)
+	

--- a/MockBattle/scenes/characters/milk_shake.tscn
+++ b/MockBattle/scenes/characters/milk_shake.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=4 format=3 uid="uid://cwm3jqyodht44"]
+
+[ext_resource type="Script" path="res://scenes/characters/milk_shake.gd" id="1_6xt6c"]
+[ext_resource type="PackedScene" uid="uid://b3qxr885pjvvh" path="res://scenes/props/health_bar.tscn" id="2_0b73y"]
+[ext_resource type="SpriteFrames" uid="uid://xw1cqmdmvufw" path="res://addons/duelyst_animated_sprites/assets/spriteframes/units/boss_malyk.tres" id="2_hpph5"]
+
+[node name="food" type="Area2D"]
+script = ExtResource("1_6xt6c")
+
+[node name="health_bar" parent="." instance=ExtResource("2_0b73y")]
+offset_left = 9.0
+offset_top = 0.0
+offset_right = 9.0
+offset_bottom = 0.0
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+position = Vector2(9.53674e-07, 0)
+scale = Vector2(1.8, 1.8)
+sprite_frames = ExtResource("2_hpph5")
+animation = &"idle"
+frame_progress = 0.859338
+offset = Vector2(40.7143, 40)

--- a/MockBattle/scenes/characters/player.gd
+++ b/MockBattle/scenes/characters/player.gd
@@ -37,7 +37,7 @@ func _ready():
 	_animated_sprite.play("idle")
 
 func _process(delta):
-	if _animated_sprite.animation != "idle":
+	if get_health() > 0 and _animated_sprite.animation != "idle":
 		if !_animated_sprite.is_playing():
 			_animated_sprite.play("idle")
 			
@@ -88,10 +88,26 @@ func get_id():
 func get_team():
 	return _team
 	
-func set_health(health: int):
-	_health = health
+func add_health(health: int):
+	if get_health() <= 0:
+		return
+		
+	set_health(get_health() + health)
+
+func _death():
+	_health = 0
 	
-	set_health_text(health)
+	set_health_text(0)
+	hide()
+	
+	
+func set_health(health: int):
+	if health <= 0:
+		return _death()
+		
+	_health = health
+	set_health_text(_health)
+	
 
 func get_health():
 	return _health
@@ -209,7 +225,7 @@ func get_most_unheath_food(instance_map):
 	for key in instance_map:
 		var food = instance_map[key].instance_node
 		
-		if target == null or (food.get_health() < target.get_health()):
+		if (target == null or (food.get_health() < target.get_health())) and food.get_health() >= 0:
 			target = food
 			
 	return target

--- a/MockBattle/scenes/characters/red_ginseng_juice.tscn
+++ b/MockBattle/scenes/characters/red_ginseng_juice.tscn
@@ -1,32 +1,21 @@
 [gd_scene load_steps=4 format=3 uid="uid://cl5jy16j6rmsy"]
 
 [ext_resource type="Script" path="res://scenes/characters/red_ginseng_juice.gd" id="1_ocl8q"]
-[ext_resource type="FontFile" uid="uid://d00vm0x0a7tly" path="res://sub_title.tres" id="2_cij34"]
-[ext_resource type="PackedScene" path="res://scenes/props/health_bar.tscn" id="3_c3s6j"]
+[ext_resource type="SpriteFrames" uid="uid://cnc7glwne5717" path="res://addons/duelyst_animated_sprites/assets/spriteframes/units/boss_gol.tres" id="3_0fhjj"]
+[ext_resource type="PackedScene" uid="uid://b3qxr885pjvvh" path="res://scenes/props/health_bar.tscn" id="3_c3s6j"]
 
-[node name="food" type="Control"]
-layout_mode = 3
-anchors_preset = 0
+[node name="food" type="Area2D"]
 script = ExtResource("1_ocl8q")
 
-[node name="character" type="ColorRect" parent="."]
-layout_mode = 0
-offset_right = 150.0
-offset_bottom = 150.0
-color = Color(0.615686, 0.309804, 0.388235, 1)
-
-[node name="Label" type="Label" parent="."]
-layout_mode = 0
-offset_left = 1.0
-offset_top = 43.0
-offset_right = 150.0
-offset_bottom = 160.0
-theme_override_fonts/font = ExtResource("2_cij34")
-theme_override_font_sizes/font_size = 30
-text = "홍삼즙"
-horizontal_alignment = 1
-
 [node name="health_bar" parent="." instance=ExtResource("3_c3s6j")]
-anchors_preset = 0
 offset_left = 9.0
+offset_top = 0.0
 offset_right = 9.0
+offset_bottom = 0.0
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+position = Vector2(9.53674e-07, 0)
+scale = Vector2(1.8, 1.8)
+sprite_frames = ExtResource("3_0fhjj")
+animation = &"run"
+offset = Vector2(40.7143, 40)

--- a/MockBattle/scenes/characters/seasoned_bellflower_root.tscn
+++ b/MockBattle/scenes/characters/seasoned_bellflower_root.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=3 format=3 uid="uid://csmtgpqxsvhl"]
+
+[ext_resource type="PackedScene" uid="uid://b3qxr885pjvvh" path="res://scenes/props/health_bar.tscn" id="2_qp5pf"]
+[ext_resource type="SpriteFrames" uid="uid://csnlul0fvhkdt" path="res://addons/duelyst_animated_sprites/assets/spriteframes/units/boss_wujin.tres" id="3_2dcxt"]
+
+[node name="food" type="Area2D"]
+
+[node name="health_bar" parent="." instance=ExtResource("2_qp5pf")]
+offset_left = 9.0
+offset_top = 0.0
+offset_right = 9.0
+offset_bottom = 0.0
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+position = Vector2(9.53674e-07, 0)
+scale = Vector2(1.8, 1.8)
+sprite_frames = ExtResource("3_2dcxt")
+animation = &"hit"
+offset = Vector2(40.7143, 40)

--- a/MockBattle/scenes/characters/stir_fried_fish_cake.gd
+++ b/MockBattle/scenes/characters/stir_fried_fish_cake.gd
@@ -1,0 +1,38 @@
+extends "res://scenes/characters/player.gd"
+
+
+func _ready():
+	set_health(150)
+	
+	food_name = "어묵볶음"
+	
+	defense = 0
+	resistance = 20
+	evasion = 0
+	critical_chance = 0
+	
+	skill_1_settings = SkillSettings.new(10, -1)
+	skill_2_settings = SkillSettings.new(15, -1)
+	
+func skill_1(team, enemies, turn, meta):
+	# 스킬 1 (발동 10)
+	# 체력이 가장 낮은 음식 체력을 30 회복시킵니다.
+	
+	super(team, enemies, turn, meta)
+	
+	var target: Player = get_most_unheath_food(team)
+
+	target.add_health(30)
+	
+		
+func skill_2(team, enemies, turn, meta):
+	# 스킬 2 (발동 15)
+	# 모든 아군 음식의 체력을 10 회복시킵니다.
+
+	super(team, enemies, turn, meta)
+	
+	for key in team:
+		var target: InstanceMap = team[key]
+		
+		target.instance_node.add_health(10)
+	

--- a/MockBattle/scenes/characters/stir_fried_fish_cake.tscn
+++ b/MockBattle/scenes/characters/stir_fried_fish_cake.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=4 format=3 uid="uid://dtestg0y8rl0b"]
+
+[ext_resource type="Script" path="res://scenes/characters/stir_fried_fish_cake.gd" id="1_j8trd"]
+[ext_resource type="PackedScene" uid="uid://b3qxr885pjvvh" path="res://scenes/props/health_bar.tscn" id="2_aepjl"]
+[ext_resource type="SpriteFrames" uid="uid://s434seb2gfj2" path="res://addons/duelyst_animated_sprites/assets/spriteframes/units/boss_harmony.tres" id="2_ksx16"]
+
+[node name="food" type="Area2D"]
+script = ExtResource("1_j8trd")
+
+[node name="health_bar" parent="." instance=ExtResource("2_aepjl")]
+offset_left = 9.0
+offset_top = 0.0
+offset_right = 9.0
+offset_bottom = 0.0
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+position = Vector2(9.53674e-07, 0)
+scale = Vector2(1.8, 1.8)
+sprite_frames = ExtResource("2_ksx16")
+animation = &"run"
+offset = Vector2(40.7143, 40)

--- a/MockBattle/singletons/settings.gd
+++ b/MockBattle/singletons/settings.gd
@@ -35,7 +35,12 @@ enum character_type {
 	JJAMBBONG,
 	CAKE,
 	RED_GINSENG_JUICE,
-	SEASONED_BELLFLOWER_ROOT
+	SEASONED_BELLFLOWER_ROOT,
+	MALA_XIANG_GUO,
+	MILK_SHAKE,
+	MALA_TANG,
+	KUNG_PAO_CHICKEN,
+	STIR_FRIED_FISH_CAKE
 }
 
 enum SkillEffectType {
@@ -141,7 +146,7 @@ var attack_position = [
 			"id": 6
 		},
 		{
-			"type": character_type.JJAJANG,
+			"type": character_type.MILK_SHAKE,
 			"id": 7
 		},
 		{

--- a/MockBattle/utils/game_helper.gd
+++ b/MockBattle/utils/game_helper.gd
@@ -32,20 +32,38 @@ static func get_skill_settings(food: Player, skill_id: int):
 			print("not found")
 
 static func get_food_instance(type):
-	var jjajang = preload("res://scenes/characters/jjajang.tscn")
-	var jjambbong = preload("res://scenes/characters/jjambbong.tscn")
-	var cake = preload("res://scenes/characters/cake.tscn")
-	var red_ginseng = preload("res://scenes/characters/red_ginseng_juice.tscn")
 
 	match type:
 		Settings.character_type.CAKE:
+			var cake = preload("res://scenes/characters/cake.tscn")
 			return cake.instantiate()
 		Settings.character_type.JJAJANG:
+			var jjajang = preload("res://scenes/characters/jjajang.tscn")
 			return jjajang.instantiate()
 		Settings.character_type.JJAMBBONG:
+			var jjambbong = preload("res://scenes/characters/jjambbong.tscn")
 			return jjambbong.instantiate()
 		Settings.character_type.RED_GINSENG_JUICE:
+			var red_ginseng = preload("res://scenes/characters/red_ginseng_juice.tscn")
 			return red_ginseng.instantiate()
+		Settings.character_type.SEASONED_BELLFLOWER_ROOT:
+			var seasoned_bellflower_root = preload("res://scenes/characters/seasoned_bellflower_root.tscn")
+			return seasoned_bellflower_root.instantiate()
+		Settings.character_type.MALA_XIANG_GUO:
+			var mala_xiang_guo = preload("res://scenes/characters/mala_xiang_guo.tscn")
+			return mala_xiang_guo.instantiate()
+		Settings.character_type.MILK_SHAKE:
+			var milk_shake = preload("res://scenes/characters/milk_shake.tscn")
+			return milk_shake.instantiate()
+		Settings.character_type.MALA_TANG:
+			var mala_tang = preload("res://scenes/characters/mala_tang.tscn")
+			return mala_tang.instantiate()
+		Settings.character_type.KUNG_PAO_CHICKEN:
+			var kung_pao_chicken = preload("res://scenes/characters/kung_pao_chicken.tscn")
+			return kung_pao_chicken.instantiate()
+		Settings.character_type.STIR_FRIED_FISH_CAKE:
+			var stir_fried_fish_cake = preload("res://scenes/characters/stir_fried_fish_cake.tscn")
+			return stir_fried_fish_cake.instantiate()
 		_:
 			print("not found")
 


### PR DESCRIPTION
- 전체 목업 캐릭터를 추가 했습니다. (총 10명)
- 스킬 유형 중, `다음 시전되는 스킬 2의 공격력을 10 증가시킵니다.` 종류의 스킬이 구현되어 있질 않았어서 간단하게 구현했습니다. 
- 이제 전체 캐릭터들을 모두 사용할 수 있습니다. 