### PR TITLE
[SVR-235] [전투 씬] 데미지 프레임 표시 추가하기

### DIFF
--- a/MockBattle/scenes/characters/jjambbong.gd
+++ b/MockBattle/scenes/characters/jjambbong.gd
@@ -21,7 +21,7 @@ func skill_1(team, enemies, turn, meta):
 	# 1열에 있는 음식 1개에게 데미지 30을 주고 손해프레임 3을 줍니다.
 	super(team, enemies, turn, meta)
 
-	var targets = get_foods_at_selected_area(1, enemies)
+	var targets = get_foods_at_selected_area(0, enemies)
 	var target = self.get_random_player(targets)
 	
 	var skill1_effect = preload("res://scenes/skill/jjambbong_skill1.tscn").instantiate()

--- a/MockBattle/scenes/characters/player.gd
+++ b/MockBattle/scenes/characters/player.gd
@@ -213,6 +213,8 @@ func take_damage(damage: int, position: int):
 	
 func check_activate_status_effect() -> bool:
 	if GameHelper.is_probability_success(resistance):
+		self.show_character_info_message("낮은 확률로 스킬을 무효화 했습니다.")
+		
 		return false
 		
 	return true
@@ -232,16 +234,32 @@ func toggle_stun(toggle: bool) -> bool:
 	
 	return stun
 	
+func _show_damage_frame_text(damage_frame: int):
+	var damage_frame_label = $character_info/damage_frame_label
+	
+	damage_frame_label.text = "<데미지 프레임: {0}>".format([damage_frame])
+	
+	damage_frame_label.visible = true
+	
+func _hide_damage_frame_text():
+	var damage_frame_label = $character_info/damage_frame_label
+	
+	damage_frame_label.visible = false
+	
 func plus_damage_frame(_damage_frame: int) -> bool:
 	if !check_activate_status_effect():
 		return false
 		
 	damage_frame += _damage_frame
 	
+	_show_damage_frame_text(damage_frame)
+	
 	return true
 	
 func remove_damage_frame():
 	damage_frame = 0
+	
+	_hide_damage_frame_text()
 	
 func skill_1(team, enemies, turn, meta):
 	_show_skill_info(1, skill_1_settings.description)

--- a/MockBattle/scenes/levels/battle.tscn
+++ b/MockBattle/scenes/levels/battle.tscn
@@ -58,13 +58,13 @@ offset_right = 1880.0
 offset_bottom = 1000.0
 theme_override_styles/panel = SubResource("StyleBoxFlat_3u88d")
 
-[node name="back" type="Sprite2D" parent="attack_panel"]
+[node name="front" type="Sprite2D" parent="attack_panel"]
 position = Vector2(20, 14)
 
 [node name="center" type="Sprite2D" parent="attack_panel"]
 position = Vector2(305, 14)
 
-[node name="front" type="Sprite2D" parent="attack_panel"]
+[node name="back" type="Sprite2D" parent="attack_panel"]
 position = Vector2(610, 14)
 
 [node name="attack_label" type="Label" parent="."]

--- a/MockBattle/scenes/props/character_info.tscn
+++ b/MockBattle/scenes/props/character_info.tscn
@@ -21,7 +21,7 @@ offset_bottom = -1.0
 visible = false
 layout_mode = 0
 offset_right = 223.0
-offset_bottom = 59.0
+offset_bottom = 64.0
 theme_override_styles/panel = SubResource("StyleBoxFlat_gxg4j")
 
 [node name="label" type="Label" parent="target_highlight"]
@@ -49,23 +49,35 @@ horizontal_alignment = 1
 
 [node name="stun_label" type="Label" parent="."]
 visible = false
-layout_mode = 2
-offset_left = 3.0
-offset_top = 29.0
-offset_right = 51.0
-offset_bottom = 57.0
+offset_left = 1.0
+offset_top = 25.0
+offset_right = 49.0
+offset_bottom = 53.0
 theme_override_colors/font_color = Color(1, 0, 0, 1)
 theme_override_colors/font_outline_color = Color(0, 0.945098, 0, 1)
 theme_override_fonts/font = ExtResource("1_3rkqd")
 theme_override_font_sizes/font_size = 15
 text = "<기절>"
 
+[node name="damage_frame_label" type="Label" parent="."]
+visible = false
+layout_mode = 2
+offset_left = 38.0
+offset_top = 45.0
+offset_right = 150.0
+offset_bottom = 73.0
+theme_override_colors/font_color = Color(1, 0, 0, 1)
+theme_override_colors/font_outline_color = Color(0, 0.945098, 0, 1)
+theme_override_fonts/font = ExtResource("1_3rkqd")
+theme_override_font_sizes/font_size = 15
+text = "<손해프레임 존재>"
+
 [node name="health_bar" parent="." instance=ExtResource("2_45sdg")]
 layout_mode = 2
-offset_left = 48.0
-offset_top = 29.0
-offset_right = 177.0
-offset_bottom = 69.0
+offset_left = 41.0
+offset_top = 26.0
+offset_right = 172.0
+offset_bottom = 44.0
 
 [node name="skill_noti" type="Panel" parent="."]
 visible = false


### PR DESCRIPTION
![image](https://github.com/not-blond-beard/savor-22b-mock-battle/assets/56328777/e9efd746-803e-4c20-9de9-7ddd83a0e4c9)

데미지 프레임을 표시했습니다.