### PR TITLE
[SVR-244] [전투 씬] 대신 맞아주기(도발) 현황 표기하기

### DIFF
--- a/MockBattle/scenes/characters/player.gd
+++ b/MockBattle/scenes/characters/player.gd
@@ -65,14 +65,26 @@ func _on_turn_changed(next_turn: int):
 		var end_turn: int = effect.started_turn + effect.persistent_turn
 		
 		if current_turn >= end_turn:
-			skill_effect.erase(effect)
+			remove_skill_effect(effect)
 			
 			if effect.type == Settings.SkillEffectType.CHANGED_PLAYER_STATUS:
 				init_player_status(effect)
 		
+		
+func toggle_aggro_message(toggle: bool):
+	$character_info/aggro.visible = toggle
 	
-func add_skill_effect(skill: SkillEffect):
-	skill_effect.append(skill)
+func remove_skill_effect(effect: SkillEffect):
+	skill_effect.erase(effect)
+	
+	if effect.type == Settings.SkillEffectType.PROTECT and effect.skill_owner_id == get_id():
+		toggle_aggro_message(false)
+	
+func add_skill_effect(effect: SkillEffect):
+	skill_effect.append(effect)
+	
+	if effect.type == Settings.SkillEffectType.PROTECT and effect.skill_owner_id == get_id():
+		toggle_aggro_message(true)
 	
 func set_health_info(health: int):
 	var health_text = $character_info/health_bar

--- a/MockBattle/scenes/levels/battle.tscn
+++ b/MockBattle/scenes/levels/battle.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Script" path="res://scenes/levels/battle.gd" id="2"]
 [ext_resource type="PackedScene" uid="uid://dc3svpklgyueu" path="res://scenes/misc/winner_alert.tscn" id="3_cvldv"]
 [ext_resource type="FontFile" uid="uid://rb827p6o1ltk" path="res://fonts/HakgyoansimSantteutdotumM.ttf" id="3_dfujj"]
-[ext_resource type="PackedScene" uid="uid://gdcc02bceflq" path="res://scenes/props/command_panel.tscn" id="3_iajgw"]
+[ext_resource type="PackedScene" path="res://scenes/props/command_panel.tscn" id="3_iajgw"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_3u88d"]
 bg_color = Color(1, 1, 1, 1)

--- a/MockBattle/scenes/props/character_info.tscn
+++ b/MockBattle/scenes/props/character_info.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=4 format=3 uid="uid://c32kjqcsfmoqh"]
+[gd_scene load_steps=5 format=3 uid="uid://c32kjqcsfmoqh"]
 
 [ext_resource type="FontFile" uid="uid://rb827p6o1ltk" path="res://fonts/HakgyoansimSantteutdotumM.ttf" id="1_3rkqd"]
 [ext_resource type="PackedScene" uid="uid://b3qxr885pjvvh" path="res://scenes/props/health_bar.tscn" id="2_45sdg"]
@@ -10,6 +10,14 @@ border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
 border_color = Color(1, 0.196078, 0.141176, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_f3opi"]
+bg_color = Color(1, 1, 1, 0)
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(0.705882, 1, 0, 1)
 
 [node name="character_info" type="Control"]
 layout_mode = 3
@@ -47,8 +55,30 @@ theme_override_font_sizes/font_size = 15
 text = "[아이디] 캐릭터 이름"
 horizontal_alignment = 1
 
+[node name="aggro" type="Panel" parent="."]
+visible = false
+layout_mode = 0
+offset_left = 2.0
+offset_top = 1.0
+offset_right = 238.0
+offset_bottom = 243.0
+theme_override_styles/panel = SubResource("StyleBoxFlat_f3opi")
+
+[node name="Label" type="Label" parent="aggro"]
+layout_mode = 0
+offset_left = 194.0
+offset_top = 3.0
+offset_right = 234.0
+offset_bottom = 26.0
+theme_override_colors/font_color = Color(0.705882, 1, 0, 1)
+theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = ExtResource("1_3rkqd")
+theme_override_font_sizes/font_size = 15
+text = "<도발>"
+
 [node name="stun_label" type="Label" parent="."]
 visible = false
+layout_mode = 0
 offset_left = 1.0
 offset_top = 25.0
 offset_right = 49.0


### PR DESCRIPTION
# Summary
- 스킬 중 ‘도발’ 능력(예시: ‘단일 공격에 대한 공격을 모두 대신 맞아줍니다’)을 사용했을 때, 현재 이 도발 능력이 발동중이라는 사실을 표기하도록 합니다.
# Detail
- 눈에 잘 띄도록 화려하게 넣어 봤습니다. 
![image](https://github.com/not-blond-beard/savor-22b-mock-battle/assets/56328777/ccae0ad0-4ffc-442a-aa5a-cb4c0c34cf68)
