### PR TITLE
[SVR-233] [전투 씬] 현재 가드 방향 표시 & 공격 방향 표시하기

### DIFF
--- a/MockBattle/scenes/characters/mala_tang.tscn
+++ b/MockBattle/scenes/characters/mala_tang.tscn
@@ -1,22 +1,18 @@
 [gd_scene load_steps=4 format=3 uid="uid://cpqcjwm2utvff"]
 
 [ext_resource type="Script" path="res://scenes/characters/mala_tang.gd" id="1_xstbk"]
-[ext_resource type="PackedScene" uid="uid://b3qxr885pjvvh" path="res://scenes/props/health_bar.tscn" id="2_201u5"]
 [ext_resource type="SpriteFrames" uid="uid://d0lsy4mvml3fs" path="res://addons/duelyst_animated_sprites/assets/spriteframes/units/boss_legion.tres" id="3_p2dg5"]
+[ext_resource type="PackedScene" uid="uid://c32kjqcsfmoqh" path="res://scenes/props/character_info.tscn" id="3_wf2o4"]
 
 [node name="food" type="Area2D"]
 script = ExtResource("1_xstbk")
 
-[node name="health_bar" parent="." instance=ExtResource("2_201u5")]
-offset_left = 9.0
-offset_top = 0.0
-offset_right = 9.0
-offset_bottom = 0.0
-
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
-position = Vector2(9.53674e-07, 0)
+position = Vector2(33.7143, 35)
 scale = Vector2(1.8, 1.8)
 sprite_frames = ExtResource("3_p2dg5")
 animation = &"idle"
 autoplay = "idle"
 offset = Vector2(40.7143, 40)
+
+[node name="character_info" parent="." instance=ExtResource("3_wf2o4")]

--- a/MockBattle/scenes/characters/mala_xiang_guo.tscn
+++ b/MockBattle/scenes/characters/mala_xiang_guo.tscn
@@ -1,22 +1,18 @@
 [gd_scene load_steps=4 format=3 uid="uid://b5yk36f1mxvl4"]
 
 [ext_resource type="Script" path="res://scenes/characters/seasoned_bellflower_root.gd" id="1_mvpoa"]
-[ext_resource type="PackedScene" uid="uid://b3qxr885pjvvh" path="res://scenes/props/health_bar.tscn" id="2_5p47q"]
+[ext_resource type="PackedScene" uid="uid://c32kjqcsfmoqh" path="res://scenes/props/character_info.tscn" id="3_1q71m"]
 [ext_resource type="SpriteFrames" uid="uid://didukbtoid7fp" path="res://addons/duelyst_animated_sprites/assets/spriteframes/units/boss_kane.tres" id="3_x1nvr"]
 
 [node name="food" type="Area2D"]
 script = ExtResource("1_mvpoa")
 
-[node name="health_bar" parent="." instance=ExtResource("2_5p47q")]
-offset_left = 9.0
-offset_top = 0.0
-offset_right = 9.0
-offset_bottom = 0.0
-
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
-position = Vector2(9.53674e-07, 0)
+position = Vector2(17, 15)
 scale = Vector2(1.8, 1.8)
 sprite_frames = ExtResource("3_x1nvr")
 animation = &"idle"
 autoplay = "idle"
 offset = Vector2(40.7143, 40)
+
+[node name="character_info" parent="." instance=ExtResource("3_1q71m")]

--- a/MockBattle/scenes/characters/player.gd
+++ b/MockBattle/scenes/characters/player.gd
@@ -44,14 +44,26 @@ var type_advantage: Dictionary = {
 	"쓴맛": {"target": "짠맛", "bonus": 10}
 }
 			
+func _show_guard_info(direction_text: String):
+	$character_info/guard_direction.text = "[가드: {0}]".format([direction_text])
+	
+func _show_guard_direction_info(direction: int):
+	_show_guard_info(GameHelper.get_skill_direction_label(direction))
+			
 func deactive_guard():
 	guard_disabled = true
+	
+	_show_guard_info("해제")
 	
 func active_guard():
 	guard_disabled = false
 	
+	_show_guard_direction_info(guard_position)
+	
 func change_guard_position(position: int): 
 	guard_position = position
+	
+	_show_guard_direction_info(guard_position)
 
 func init_player_status(effect: SkillEffect):
 	var origin_status: int = self.get(effect.target_stat)
@@ -196,6 +208,8 @@ func _show_info():
 	var label = $character_info/id_label
 	
 	label.text = "[{0}][{1}] {2}".format([food_type, str(get_id()), food_name])
+	
+	_show_guard_direction_info(guard_position)
 		
 func show_character_info_message(message: String):
 	var container = $character_info/skill_noti
@@ -209,7 +223,7 @@ func show_character_info_message(message: String):
 	
 	container.hide()
 	
-func _show_guard_info(guard_direciton: int):
+func _show_guard_skill_info(guard_direciton: int):
 	var direction = GameHelper.get_skill_direction_label(guard_direciton)
 	
 	show_character_info_message("[{0}] 방향으로 가드를 전환했습니다.".format([direction]))
@@ -313,7 +327,7 @@ func skill_2(team, enemies, turn, meta):
 	play_special_animation("attack")
 	
 func skill_guard(team, enemies, turn, meta):
-	_show_guard_info(meta)
+	_show_guard_skill_info(meta)
 	change_guard_position(meta)
 
 func get_is_enemy(target):
@@ -365,4 +379,3 @@ func play_all_target_skill_animation(team_code):
 	enemies_panel.add_child(all_target_skill_effect)
 	all_target_skill_effect.get_node("AnimatedSprite2D").frame = 0
 	all_target_skill_effect.get_node("AnimatedSprite2D").play()
-

--- a/MockBattle/scenes/characters/player.gd
+++ b/MockBattle/scenes/characters/player.gd
@@ -208,9 +208,16 @@ func show_character_info_message(message: String):
 	await get_tree().create_timer(2.0).timeout
 	
 	container.hide()
+	
+func _show_guard_info(guard_direciton: int):
+	var direction = GameHelper.get_skill_direction_label(guard_direciton)
+	
+	show_character_info_message("[{0}] 방향으로 가드를 전환했습니다.".format([direction]))
 		
-func _show_skill_info(skill_type: int, description: String):
-	show_character_info_message("[Skill {0}]을(를) 시전했다.\n{1}".format([str(skill_type), description]))
+func _show_skill_info(skill_type: int, description: String, target_direction: int):
+	var direction = GameHelper.get_skill_direction_label(target_direction)
+	
+	show_character_info_message("[{0}] [Skill {1}]을(를) 시전했다.\n{2}".format([direction, str(skill_type), description]))
 	
 
 func play_special_animation(animation: String):
@@ -298,14 +305,15 @@ func remove_damage_frame():
 	_hide_damage_frame_text()
 	
 func skill_1(team, enemies, turn, meta):
-	_show_skill_info(1, skill_1_settings.description)
+	_show_skill_info(1, skill_1_settings.description, skill_1_settings.target_direction)
 	play_special_animation("attack")
 	
 func skill_2(team, enemies, turn, meta):
-	_show_skill_info(2, skill_2_settings.description)
+	_show_skill_info(2, skill_2_settings.description, skill_2_settings.target_direction)
 	play_special_animation("attack")
 	
 func skill_guard(team, enemies, turn, meta):
+	_show_guard_info(meta)
 	change_guard_position(meta)
 
 func get_is_enemy(target):

--- a/MockBattle/scenes/characters/seasoned_bellflower_root.tscn
+++ b/MockBattle/scenes/characters/seasoned_bellflower_root.tscn
@@ -1,20 +1,16 @@
 [gd_scene load_steps=3 format=3 uid="uid://bf4faooi6a3cj"]
 
-[ext_resource type="PackedScene" uid="uid://b3qxr885pjvvh" path="res://scenes/props/health_bar.tscn" id="2_qp5pf"]
+[ext_resource type="PackedScene" uid="uid://c32kjqcsfmoqh" path="res://scenes/props/character_info.tscn" id="2_pjp83"]
 [ext_resource type="SpriteFrames" uid="uid://csnlul0fvhkdt" path="res://addons/duelyst_animated_sprites/assets/spriteframes/units/boss_wujin.tres" id="3_2dcxt"]
 
 [node name="food" type="Area2D"]
 
-[node name="health_bar" parent="." instance=ExtResource("2_qp5pf")]
-offset_left = 9.0
-offset_top = 0.0
-offset_right = 9.0
-offset_bottom = 0.0
-
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
-position = Vector2(9.53674e-07, 0)
+position = Vector2(17, 19)
 scale = Vector2(1.8, 1.8)
 sprite_frames = ExtResource("3_2dcxt")
 animation = &"idle"
 autoplay = "idle"
 offset = Vector2(40.7143, 40)
+
+[node name="character_info" parent="." instance=ExtResource("2_pjp83")]

--- a/MockBattle/scenes/characters/stir_fried_fish_cake.tscn
+++ b/MockBattle/scenes/characters/stir_fried_fish_cake.tscn
@@ -1,22 +1,18 @@
 [gd_scene load_steps=4 format=3 uid="uid://dachkuad0no36"]
 
 [ext_resource type="Script" path="res://scenes/characters/stir_fried_fish_cake.gd" id="1_j8trd"]
-[ext_resource type="PackedScene" uid="uid://b3qxr885pjvvh" path="res://scenes/props/health_bar.tscn" id="2_aepjl"]
 [ext_resource type="SpriteFrames" uid="uid://s434seb2gfj2" path="res://addons/duelyst_animated_sprites/assets/spriteframes/units/boss_harmony.tres" id="2_ksx16"]
+[ext_resource type="PackedScene" uid="uid://c32kjqcsfmoqh" path="res://scenes/props/character_info.tscn" id="3_0v81m"]
 
 [node name="food" type="Area2D"]
 script = ExtResource("1_j8trd")
 
-[node name="health_bar" parent="." instance=ExtResource("2_aepjl")]
-offset_left = 9.0
-offset_top = 0.0
-offset_right = 9.0
-offset_bottom = 0.0
-
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
-position = Vector2(9.53674e-07, 0)
+position = Vector2(19, 17)
 scale = Vector2(1.8, 1.8)
 sprite_frames = ExtResource("2_ksx16")
 animation = &"idle"
 autoplay = "idle"
 offset = Vector2(40.7143, 40)
+
+[node name="character_info" parent="." instance=ExtResource("3_0v81m")]

--- a/MockBattle/scenes/levels/battle.tscn
+++ b/MockBattle/scenes/levels/battle.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Script" path="res://scenes/levels/battle.gd" id="2"]
 [ext_resource type="PackedScene" uid="uid://dc3svpklgyueu" path="res://scenes/misc/winner_alert.tscn" id="3_cvldv"]
 [ext_resource type="FontFile" uid="uid://rb827p6o1ltk" path="res://fonts/HakgyoansimSantteutdotumM.ttf" id="3_dfujj"]
-[ext_resource type="PackedScene" path="res://scenes/props/command_panel.tscn" id="3_iajgw"]
+[ext_resource type="PackedScene" uid="uid://gdcc02bceflq" path="res://scenes/props/command_panel.tscn" id="3_iajgw"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_3u88d"]
 bg_color = Color(1, 1, 1, 1)

--- a/MockBattle/scenes/props/character_info.tscn
+++ b/MockBattle/scenes/props/character_info.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=5 format=3 uid="uid://c32kjqcsfmoqh"]
+[gd_scene load_steps=6 format=3 uid="uid://c32kjqcsfmoqh"]
 
 [ext_resource type="FontFile" uid="uid://rb827p6o1ltk" path="res://fonts/HakgyoansimSantteutdotumM.ttf" id="1_3rkqd"]
 [ext_resource type="PackedScene" uid="uid://b3qxr885pjvvh" path="res://scenes/props/health_bar.tscn" id="2_45sdg"]
@@ -9,7 +9,7 @@ border_width_left = 2
 border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
-border_color = Color(1, 0.196078, 0.141176, 1)
+border_color = Color(0.933333, 0.933333, 0.933333, 1)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_f3opi"]
 bg_color = Color(1, 1, 1, 0)
@@ -19,41 +19,36 @@ border_width_right = 3
 border_width_bottom = 3
 border_color = Color(0.705882, 1, 0, 1)
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_uk4i8"]
+bg_color = Color(0.6, 0.6, 0.6, 0)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.823529, 0, 0, 1)
+
 [node name="character_info" type="Control"]
 layout_mode = 3
 anchors_preset = 0
-offset_top = -1.0
-offset_bottom = -1.0
+offset_left = 1.0
+offset_right = 1.0
 
-[node name="target_highlight" type="Panel" parent="."]
-visible = false
-layout_mode = 0
-offset_right = 223.0
-offset_bottom = 64.0
+[node name="outline" type="Panel" parent="."]
+offset_right = 241.0
+offset_bottom = 241.0
 theme_override_styles/panel = SubResource("StyleBoxFlat_gxg4j")
-
-[node name="label" type="Label" parent="target_highlight"]
-layout_mode = 0
-offset_left = 159.0
-offset_top = 33.0
-offset_right = 221.0
-offset_bottom = 58.0
-theme_override_colors/font_color = Color(1, 0.196078, 0.141176, 1)
-theme_override_font_sizes/font_size = 15
-text = "<target>"
 
 [node name="id_label" type="Label" parent="."]
 layout_mode = 2
-offset_left = 19.0
+offset_left = 8.0
 offset_top = 7.0
-offset_right = 148.0
+offset_right = 162.0
 offset_bottom = 25.0
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_colors/font_outline_color = Color(0, 0.945098, 0, 1)
 theme_override_fonts/font = ExtResource("1_3rkqd")
 theme_override_font_sizes/font_size = 15
 text = "[아이디] 캐릭터 이름"
-horizontal_alignment = 1
 
 [node name="aggro" type="Panel" parent="."]
 visible = false
@@ -66,10 +61,10 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_f3opi")
 
 [node name="Label" type="Label" parent="aggro"]
 layout_mode = 0
-offset_left = 194.0
-offset_top = 3.0
-offset_right = 234.0
-offset_bottom = 26.0
+offset_left = 192.0
+offset_top = 6.0
+offset_right = 232.0
+offset_bottom = 29.0
 theme_override_colors/font_color = Color(0.705882, 1, 0, 1)
 theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
 theme_override_fonts/font = ExtResource("1_3rkqd")
@@ -79,10 +74,10 @@ text = "<도발>"
 [node name="stun_label" type="Label" parent="."]
 visible = false
 layout_mode = 0
-offset_left = 1.0
-offset_top = 25.0
-offset_right = 49.0
-offset_bottom = 53.0
+offset_left = 10.0
+offset_top = 47.0
+offset_right = 58.0
+offset_bottom = 75.0
 theme_override_colors/font_color = Color(1, 0, 0, 1)
 theme_override_colors/font_outline_color = Color(0, 0.945098, 0, 1)
 theme_override_fonts/font = ExtResource("1_3rkqd")
@@ -92,10 +87,10 @@ text = "<기절>"
 [node name="damage_frame_label" type="Label" parent="."]
 visible = false
 layout_mode = 2
-offset_left = 38.0
-offset_top = 45.0
-offset_right = 150.0
-offset_bottom = 73.0
+offset_left = 119.0
+offset_top = 46.0
+offset_right = 231.0
+offset_bottom = 74.0
 theme_override_colors/font_color = Color(1, 0, 0, 1)
 theme_override_colors/font_outline_color = Color(0, 0.945098, 0, 1)
 theme_override_fonts/font = ExtResource("1_3rkqd")
@@ -104,15 +99,15 @@ text = "<손해프레임 존재>"
 
 [node name="health_bar" parent="." instance=ExtResource("2_45sdg")]
 layout_mode = 2
-offset_left = 41.0
+offset_left = 9.0
 offset_top = 26.0
-offset_right = 172.0
+offset_right = 140.0
 offset_bottom = 44.0
 
 [node name="skill_noti" type="Panel" parent="."]
 visible = false
 layout_mode = 2
-offset_left = 1.0
+offset_left = 6.0
 offset_top = 126.0
 offset_right = 235.0
 offset_bottom = 236.0
@@ -129,9 +124,26 @@ autowrap_mode = 2
 
 [node name="buff_label" type="Label" parent="."]
 layout_mode = 0
-offset_left = 22.0
-offset_top = -14.0
-offset_right = 82.0
-offset_bottom = 12.0
+offset_left = 113.0
+offset_top = 22.0
+offset_right = 173.0
+offset_bottom = 48.0
 theme_override_colors/font_color = Color(1, 0.454902, 0, 1)
 theme_override_font_sizes/font_size = 12
+
+[node name="target_highlight" type="Panel" parent="."]
+visible = false
+layout_mode = 0
+offset_right = 241.0
+offset_bottom = 241.0
+theme_override_styles/panel = SubResource("StyleBoxFlat_uk4i8")
+
+[node name="label" type="Label" parent="target_highlight"]
+layout_mode = 0
+offset_left = 172.0
+offset_top = 214.0
+offset_right = 234.0
+offset_bottom = 239.0
+theme_override_colors/font_color = Color(1, 0.196078, 0.141176, 1)
+theme_override_font_sizes/font_size = 15
+text = "<target>"

--- a/MockBattle/scenes/props/character_info.tscn
+++ b/MockBattle/scenes/props/character_info.tscn
@@ -61,7 +61,7 @@ layout_mode = 0
 offset_left = 2.0
 offset_top = 1.0
 offset_right = 238.0
-offset_bottom = 243.0
+offset_bottom = 239.0
 theme_override_styles/panel = SubResource("StyleBoxFlat_f3opi")
 
 [node name="Label" type="Label" parent="aggro"]
@@ -113,16 +113,16 @@ offset_bottom = 44.0
 visible = false
 layout_mode = 2
 offset_left = 1.0
-offset_top = 155.0
+offset_top = 126.0
 offset_right = 235.0
-offset_bottom = 237.0
+offset_bottom = 236.0
 
 [node name="label" type="Label" parent="skill_noti"]
 layout_mode = 0
 offset_left = 1.0
 offset_top = 1.0
 offset_right = 233.0
-offset_bottom = 83.0
+offset_bottom = 109.0
 horizontal_alignment = 1
 vertical_alignment = 1
 autowrap_mode = 2

--- a/MockBattle/scenes/props/character_info.tscn
+++ b/MockBattle/scenes/props/character_info.tscn
@@ -71,13 +71,24 @@ theme_override_fonts/font = ExtResource("1_3rkqd")
 theme_override_font_sizes/font_size = 15
 text = "<도발>"
 
+[node name="guard_direction" type="Label" parent="."]
+offset_left = 116.0
+offset_top = 27.0
+offset_right = 176.0
+offset_bottom = 43.0
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_colors/font_outline_color = Color(0, 0.945098, 0, 1)
+theme_override_fonts/font = ExtResource("1_3rkqd")
+theme_override_font_sizes/font_size = 12
+text = "[가드 방향]"
+
 [node name="stun_label" type="Label" parent="."]
 visible = false
 layout_mode = 0
-offset_left = 10.0
-offset_top = 47.0
-offset_right = 58.0
-offset_bottom = 75.0
+offset_left = 7.0
+offset_top = 46.0
+offset_right = 55.0
+offset_bottom = 74.0
 theme_override_colors/font_color = Color(1, 0, 0, 1)
 theme_override_colors/font_outline_color = Color(0, 0.945098, 0, 1)
 theme_override_fonts/font = ExtResource("1_3rkqd")
@@ -124,9 +135,9 @@ autowrap_mode = 2
 
 [node name="buff_label" type="Label" parent="."]
 layout_mode = 0
-offset_left = 113.0
+offset_left = 174.0
 offset_top = 22.0
-offset_right = 173.0
+offset_right = 234.0
 offset_bottom = 48.0
 theme_override_colors/font_color = Color(1, 0.454902, 0, 1)
 theme_override_font_sizes/font_size = 12

--- a/MockBattle/utils/game_helper.gd
+++ b/MockBattle/utils/game_helper.gd
@@ -9,6 +9,13 @@ static func calculate_percentage(original: int, percentage: int) -> float:
 	var difference = original * (float(percentage) / 100.0)
 	return difference
 
+static func get_skill_direction_label(direction: int):
+	match direction:
+		0:
+			return "하단"
+		1: 
+			return "중단"
+
 static func get_skill(food: Player, skill_id: int):
 	match skill_id:
 		0:


### PR DESCRIPTION
# Summary
- 현재 가드 방향 표시
  - 가드 해제도 표시합니다
- 공격 시 공격 방향 표시

# Detail
![image](https://github.com/not-blond-beard/savor-22b-mock-battle/assets/56328777/254afef6-58fd-4523-8a70-004472b56f0e)
![image](https://github.com/not-blond-beard/savor-22b-mock-battle/assets/56328777/6d4176b6-e98a-4038-af91-4ecaca826987)
